### PR TITLE
update node-xiaomi-smart-home to 1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.1",
   "description": "A node to receive input from the Xiaomi Smart Home kit on the same LAN",
   "dependencies": {
-    "node-xiaomi-smart-home": "^0.1.4"
+    "node-xiaomi-smart-home": "^1.4.1"
   },
   "keywords": [
     "node-red", "xiaomi"

--- a/xiaomi-home.js
+++ b/xiaomi-home.js
@@ -9,6 +9,15 @@ module.exports = function(RED) {
         RED.nodes.createNode(this,config);
         var node = this;
 
+		//Clean up procedure before re-deploy
+		node.on('close', function(removed, doneFunction) {
+			hub.stop();
+			hub = null;
+			if (typeof doneFunction === 'function')
+				doneFunction();
+			RED.log.info("node-red-contrib-xiaomi-home closing done...");
+		});
+
 		hub.on('data.th', function (sid, temperature, humidity) {
 			var msg = {};
 			msg.title = 'th';


### PR DESCRIPTION
This should fix a couple of major bugs. Especially the one at 
**node-xiaomi-smart-home/build/Hub.js:70** 
when 'sensor' variable is null sometime.

Cleaning up 'hub' object when NodeRED is re-deployed, otherwise multiple 'hub' object persist in memory and causing multiple messages to arrive for each event received from Xiaomi gateway.
